### PR TITLE
build: update to latest tree-sitter-slint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "memchr"
@@ -53,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slintgen"
 version = "0.1.0"
 dependencies = [
@@ -62,20 +71,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter"
-version = "0.20.10"
+name = "streaming-iterator"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac95b18f0f727aaaa012bd5179a1916706ee3ed071920fdbda738750b0c0bf5"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c199356c799a8945965bb5f2c55b2ad9d9aa7c4b4f6e587fe9dea0bc715e5f9c"
 
 [[package]]
 name = "tree-sitter-slint"
 version = "0.0.1"
-source = "git+https://github.com/slint-ui/tree-sitter-slint#4a0558cc0fcd7a6110815b9bbd7cc12d7ab31e74"
+source = "git+https://github.com/slint-ui/tree-sitter-slint?rev=f11da7e6#f11da7e62051ba8b9d4faa299c26de8aeedfc1cd"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tree-sitter = "0.20.10"
-tree-sitter-slint = {git = "https://github.com/slint-ui/tree-sitter-slint"}
+tree-sitter = "0.24.5"
+tree-sitter-slint = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "f11da7e6" }
 
 [build-dependencies]
-cc="*"
-
+cc = "1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     // Initialize Tree-sitter parser
     let mut parser = Parser::new();
     parser
-        .set_language(tree_sitter_slint::language())
+        .set_language(&tree_sitter_slint::LANGUAGE.into())
         .expect("Error loading Slint grammar");
 
     // Read and parse the Slint file


### PR DESCRIPTION
It's intended to be compatible with Slint 1.9.